### PR TITLE
feat: `transform` subcommand

### DIFF
--- a/docs/commands/transform.rst
+++ b/docs/commands/transform.rst
@@ -1,5 +1,35 @@
 .. _commands-transform:
 
-# transform
 
-The ``transform`` command takes as input a set of genotypes and a list of haplotypes (specified as a .hap file) and outputs a set of haplotype "genotypes" (in a genotypes file, like a VCF).
+transform
+=========
+
+Transform a set of genotypes via a list of haplotypes. Create a new VCF containing haplotypes instead of variants.
+
+The ``transform`` command takes as input a set of genotypes in VCF and a list of haplotypes (specified as a :doc:`.hap file </formats/haplotypes>`) and outputs a set of haplotype "genotypes" in VCF.
+
+Usage
+~~~~~
+.. code-block:: bash
+
+	haptools transform \
+	--region TEXT \
+	--sample SAMPLE \
+	--samples-file FILENAME \
+	--output PATH \
+	--verbosity [CRITICAL|ERROR|WARNING|INFO|DEBUG|NOTSET] \
+	GENOTYPES HAPLOTYPES
+
+Examples
+~~~~~~~~
+.. code-block:: bash
+
+	haptools transform tests/data/example.vcf.gz tests/data/example.hap.gz | less
+
+Detailed Usage
+~~~~~~~~~~~~~~
+
+.. click:: haptools.__main__:main
+   :prog: haptools
+   :show-nested:
+   :commands: transform

--- a/docs/commands/transform.rst
+++ b/docs/commands/transform.rst
@@ -1,0 +1,5 @@
+.. _commands-transform:
+
+# transform
+
+The ``transform`` command takes as input a set of genotypes and a list of haplotypes (specified as a .hap file) and outputs a set of haplotype "genotypes" (in a genotypes file, like a VCF).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@
 
    commands/simgenotype.rst
    commands/simphenotype.rst
+   commands/transform.rst
 
 .. toctree::
    :caption: API

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -90,7 +90,7 @@ def simphenotype(vcf, hap, simu_rep, simu_hsq, simu_k, simu_qt, simu_cc, out):
     simulate_pt(vcf, hap, simu_rep, \
         simu_hsq, simu_k, simu_qt, simu_cc, out)
 
-@main.command()
+@main.command(short_help="Transform a genotypes matrix via a set of haplotypes")
 @click.argument("genotypes", type=click.Path(exists=True, path_type=Path))
 @click.argument("haplotypes", type=click.Path(exists=True, path_type=Path))
 @click.option(
@@ -141,7 +141,7 @@ def simphenotype(vcf, hap, simu_rep, simu_hsq, simu_k, simu_qt, simu_cc, out):
     help="The level of verbosity desired",
 )
 def transform(
-    genotypes: Path,
+    gnotypes: Path,
     haplotypes: Path,
     region: str = None,
     samples: tuple[str] = tuple(),
@@ -150,14 +150,16 @@ def transform(
     verbosity: str = 'CRITICAL',
 ):
     """
-    Transform a genotypes matrix via a set of haplotypes
+    Creates a VCF composed of haplotypes
 
-    GENOTYPES must be formatted as a VCF and
+    GENOTYPES must be formatted as a VCF and HAPLOTYPES must be formatted according
+    to the .hap format spec
 
-    HAPLOTYPES must be formatted according to the .hap format spec
-
-    Ex: haptools transform tests/data/example.vcf.gz tests/data/example.hap.gz > example_haps.vcf
     \f
+    Examples
+    --------
+    >>> haptools transform tests/data/example.vcf.gz tests/data/example.hap.gz > example_haps.vcf
+
     Parameters
     ----------
     genotypes : Path
@@ -171,7 +173,7 @@ def transform(
     samples_file : Path, optional
         A single column txt file containing a list of the samples (one per line) to
         subset from the genotypes file
-    output : TextIO, optional
+    output : Path, optional
         The location to which to write output
     verbosity : str, optional
         The level of verbosity desired in messages written to stderr

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -7,20 +7,23 @@ TODO:
 - group options
 """
 
+from __future__ import annotations
 import sys
 import click
+from pathlib import Path
 
-from .simgenotype.sim_admixture import simulate_gt, write_breakpoints
-from .karyogram.karyogram import plot_karyogram
-from .simphenotype.sim_phenotypes import simulate_pt
+# AVOID IMPORTING ANYTHING HERE
+# any imports you put here will make it slower to use the command line client
+# a basic haptools --help should be quick and require very few imports, for example
+
 
 @click.group()
 @click.version_option()
 def main():
     """
-    haptools: Simulate phenotypes for GWAS and subsequent fine-mapping
+    haptools: Simulate genotypes and phenotypes for GWAS and subsequent fine-mapping
 
-    Use real variants to simulate real, biological LD patterns.
+    Use real variants to simulate biological LD patterns and traits.
     """
     pass
 
@@ -34,6 +37,7 @@ def simgenotype(invcf, sample_info, model, mapdir, out):
     """
     Use the tool to simulate genotypes
     """
+    from .sim_admixture import simulate_gt, write_breakpoints
     samples, breakpoints = simulate_gt(model, mapdir)
     write_breakpoints(samples, breakpoints, out)
 
@@ -48,6 +52,7 @@ def karyogram(sample_name, chrx, sample_file, title, centromeres, out):
     """
     Use the tool to visualize breakpoints.
     """
+    from .karyogram import plot_karyogram
     plot_karyogram(sample_file, title, centromeres, out, sample_name, chrx)
 
 ############ Haptools simphenotype ###############
@@ -75,6 +80,7 @@ def simphenotype(vcf, hap, simu_rep, simu_hsq, simu_k, simu_qt, simu_cc, out):
     """
     Haplotype-aware phenotype simulation
     """
+    from .sim_phenotypes import simulate_pt
     # Basic checks on input
     # TODO - check VCF zipped, check only one of simu-qt/simu-cc,
     # check values of other inputs
@@ -83,6 +89,128 @@ def simphenotype(vcf, hap, simu_rep, simu_hsq, simu_k, simu_qt, simu_cc, out):
     # Run simulation
     simulate_pt(vcf, hap, simu_rep, \
         simu_hsq, simu_k, simu_qt, simu_cc, out)
+
+@main.command()
+@click.argument("genotypes", type=click.Path(exists=True, path_type=Path))
+@click.argument("haplotypes", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--region",
+    type=str,
+    default=None,
+    show_default="all genotypes",
+    help="""
+    The region from which to extract genotypes; ex: 'chr1:1234-34566' or 'chr7'\n
+    For this to work, the VCF must be indexed and the seqname must match!""",
+)
+@click.option(
+    "-s",
+    "--sample",
+    "samples",
+    type=str,
+    multiple=True,
+    show_default="all samples",
+    help=(
+        "A list of the samples to subset from the genotypes file (ex: '-s sample1 -s"
+        " sample2')"
+    ),
+)
+@click.option(
+    "-S",
+    "--samples-file",
+    type=click.File("r"),
+    show_default="all samples",
+    help=(
+        "A single column txt file containing a list of the samples (one per line) to"
+        " subset from the genotypes file"
+    ),
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.File("w"),
+    default="-",
+    show_default="stdout",
+    help="A VCF file containing haplotype 'genotypes'",
+)
+@click.option(
+    "-v",
+    "--verbosity",
+    type=click.Choice(["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]),
+    default="ERROR",
+    show_default="only errors",
+    help="The level of verbosity desired",
+)
+def transform(
+    genotypes: Path,
+    haplotypes: Path,
+    region: str = None,
+    samples: tuple[str] = tuple(),
+    samples_file: Path = None,
+    output: TextIO = sys.stdout,
+    verbosity: str = 'CRITICAL',
+):
+    """
+    Transform a genotypes matrix via a set of haplotypes
+
+    GENOTYPES must be formatted as a VCF and
+
+    HAPLOTYPES must be formatted according to the .hap format spec
+
+    Ex: haptools transform tests/data/example.vcf.gz tests/data/example.hap.gz > example_haps.vcf
+    \f
+    Parameters
+    ----------
+    genotypes : Path
+        The path to the genotypes in VCF format
+    haplotypes : Path
+        The path to the haplotypes in a .hap file
+    region : str, optional
+        See documentation for :py:meth:`~.data.Genotypes.read`
+    sample : Tuple[str], optional
+        See documentation for :py:meth:`~.data.Genotypes.read`
+    samples_file : Path, optional
+        A single column txt file containing a list of the samples (one per line) to
+        subset from the genotypes file
+    output : TextIO, optional
+        The location to which to write output
+    verbosity : str, optional
+        The level of verbosity desired in messages written to stderr
+    """
+    import logging
+
+    from haptools import data
+    from .haplotype import HaptoolsHaplotype
+    log = logging.getLogger("run")
+    logging.basicConfig(
+        format="[%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)",
+        level=verbosity,
+    )
+    # handle samples
+    if samples and samples_file:
+        raise click.UsageError(
+            "You may only use one of --sample or --samples-file but not both."
+        )
+    if samples_file:
+        with samples_file as samps_file:
+            samples = samps_file.read().splitlines()
+    elif samples:
+        # needs to be converted from tuple to list
+        samples = list(samples)
+    else:
+        samples = None
+    # load data
+    log.info("Loading genotypes")
+    gt = data.Genotypes(genotypes)
+    gt.read(region=region, samples=samples)
+    log.info("Discarding multiallelic variants")
+    gt.check_biallelic(discard_also=True)
+    gt.check_phase()
+    log.info("Loading haplotypes")
+    hp = data.Haplotypes(haplotypes, haplotype=HaptoolsHaplotype)
+    hp.read(region=region)
+    hp_gt = hp.transform(gt)
+    # TODO: write hp_gt to output
+
 
 if __name__ == "__main__":
     # run the CLI if someone tries 'python -m haptools' on the command line

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -127,8 +127,8 @@ def simphenotype(vcf, hap, simu_rep, simu_hsq, simu_k, simu_qt, simu_cc, out):
 @click.option(
     "-o",
     "--output",
-    type=click.File("w"),
-    default="-",
+    type=click.Path(path_type=Path),
+    default=Path("-"),
     show_default="stdout",
     help="A VCF file containing haplotype 'genotypes'",
 )
@@ -146,7 +146,7 @@ def transform(
     region: str = None,
     samples: tuple[str] = tuple(),
     samples_file: Path = None,
-    output: TextIO = sys.stdout,
+    output: Path = Path("-"),
     verbosity: str = 'CRITICAL',
 ):
     """
@@ -200,7 +200,7 @@ def transform(
         samples = None
     # load data
     log.info("Loading genotypes")
-    gt = data.Genotypes(genotypes)
+    gt = data.GenotypesRefAlt(genotypes)
     gt.read(region=region, samples=samples)
     log.info("Discarding multiallelic variants")
     gt.check_biallelic(discard_also=True)
@@ -209,7 +209,8 @@ def transform(
     hp = data.Haplotypes(haplotypes, haplotype=HaptoolsHaplotype)
     hp.read(region=region)
     hp_gt = hp.transform(gt)
-    # TODO: write hp_gt to output
+    hp_gt.fname = output
+    hp_gt.write()
 
 
 if __name__ == "__main__":

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -13,8 +13,8 @@ import click
 from pathlib import Path
 
 # AVOID IMPORTING ANYTHING HERE
-# any imports you put here will make it slower to use the command line client
-# a basic haptools --help should be quick and require very few imports, for example
+# any imports we put here will make it slower to use the command line client
+# a basic "haptools --help" should be quick and require very few imports, for example
 
 
 @click.group()

--- a/haptools/data/__init__.py
+++ b/haptools/data/__init__.py
@@ -1,5 +1,5 @@
 from .data import Data
-from .genotypes import Genotypes
+from .genotypes import Genotypes, GenotypesRefAlt
 from .phenotypes import Phenotypes
 from .covariates import Covariates
 from .haplotypes import Extra, Variant, Haplotype, Haplotypes

--- a/haptools/data/data.py
+++ b/haptools/data/data.py
@@ -45,12 +45,23 @@ class Data(ABC):
         """
         pass
 
+    def unset(self) -> bool:
+        """
+        Whether the data has been loaded into the object yet
+
+        Returns
+        -------
+        bool
+            True if :py:attr:`~.Data.data` is None else False
+        """
+        return self.data is None
+
     @abstractmethod
     def read(self):
         """
         Read the raw file contents into the class properties
         """
-        if self.data is not None:
+        if self.unset():
             self.log.warning("The data has already been loaded. Overriding.")
 
     @abstractmethod

--- a/haptools/data/data.py
+++ b/haptools/data/data.py
@@ -61,7 +61,7 @@ class Data(ABC):
         """
         Read the raw file contents into the class properties
         """
-        if self.unset():
+        if not self.unset():
             self.log.warning("The data has already been loaded. Overriding.")
 
     @abstractmethod

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from logging import getLogger, Logger
 
 import numpy as np
+import numpy.typing as npt
 from pysam import VariantFile
 from cyvcf2 import VCF, Variant
 
@@ -17,7 +18,7 @@ class Genotypes(Data):
 
     Attributes
     ----------
-    data : np.array
+    data : npt.NDArray
         The genotypes in an n (samples) x p (variants) x 2 (strands) array
     fname : Path
         The path to the read-only file containing the data

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -75,6 +75,7 @@ class Genotypes(Data):
             self,
             region: str = None,
             samples: list[str] = None,
+            variants: set[str] = None,
             max_variants: int = None
         ):
         """
@@ -97,6 +98,11 @@ class Genotypes(Data):
             A subset of the samples from which to extract genotypes
 
             Defaults to loading genotypes from all samples
+        variants : set[str], optional
+            A set of variant IDs for which to extract genotypes
+
+            All other variants will be ignored. This may be useful if you're running
+            out of memory.
         max_variants : int, optional
             The maximum mumber of variants to load from the file. Setting this value
             helps preallocate the arrays, making the process faster and less memory
@@ -123,6 +129,8 @@ class Genotypes(Data):
                 "append to an ever-growing array, which can lead to memory overuse!"
             )
             for variant in vcf(region):
+                if variants is not None and variant.ID not in variants:
+                    continue
                 # save meta information about each variant
                 self.variants.append((variant.ID, variant.CHROM, variant.POS, variant.aaf))
                 # extract the genotypes to a matrix of size n x p x 3
@@ -156,6 +164,8 @@ class Genotypes(Data):
             num_seen = 0
             # save just the variant info we need and discard the rest (to save memory!)
             for variant in vcf(region):
+                if variants is not None and variant.ID not in variants:
+                    continue
                 # save meta information about each variant
                 self.variants[num_seen] = (variant.ID, variant.CHROM, variant.POS, variant.aaf)
                 # extract the genotypes to a matrix of size n x p x 3
@@ -184,7 +194,7 @@ class Genotypes(Data):
         self.data = self.data.transpose((1, 0, 2))
 
     def __iter__(
-        self, region: str = None, samples: list[str] = None
+        self, region: str = None, samples: list[str] = None, variants: set[str] = None
     ) -> Iterator[namedtuple]:
         """
         Read genotypes from a VCF line by line without storing anything
@@ -201,6 +211,11 @@ class Genotypes(Data):
             A subset of the samples from which to extract genotypes
 
             Defaults to loading genotypes from all samples
+        variants : set[str], optional
+            A set of variant IDs for which to extract genotypes
+
+            All other variants will be ignored. This may be useful if you're running
+            out of memory.
 
         Yields
         ------
@@ -213,6 +228,8 @@ class Genotypes(Data):
         Record = namedtuple("Record", "data samples variants")
         # load all info into memory
         for variant in vcf(region):
+            if variants is not None and variant.ID not in variants:
+                continue
             # save meta information about each variant
             variants = np.array(
                 (variant.ID, variant.CHROM, variant.POS, variant.aaf),
@@ -361,6 +378,7 @@ class GenotypesPLINK(Genotypes):
             self,
             region: str = None,
             samples: list[str] = None,
+            variants: set[str] = None,
             max_variants: int = None
         ):
         """
@@ -378,6 +396,11 @@ class GenotypesPLINK(Genotypes):
             A subset of the samples from which to extract genotypes
 
             Defaults to loading genotypes from all samples
+        variants : set[str], optional
+            A set of variant IDs for which to extract genotypes
+
+            All other variants will be ignored. This may be useful if you're running
+            out of memory.
         max_variants : int, optional
             The maximum mumber of variants to load from the file. Setting this value
             helps preallocate the arrays, making the process faster and less memory

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -475,8 +475,6 @@ class GenotypesRefAlt(Genotypes):
         # make sure the header is properly structured
         for contig in set(self.variants["chrom"]):
             vcf.header.contigs.add(contig)
-        for sample in self.samples:
-            vcf.header.add_sample(sample)
         vcf.header.add_meta(
             "FORMAT",
             items=[
@@ -486,6 +484,9 @@ class GenotypesRefAlt(Genotypes):
                 ("Description", "Genotype"),
             ],
         )
+        for sample in self.samples:
+            vcf.header.add_sample(sample)
+        self.log.info("Writing VCF records")
         for var_idx, var in enumerate(self.variants):
             rec = {
                 "contig": var["chrom"],
@@ -508,28 +509,26 @@ class GenotypesRefAlt(Genotypes):
         vcf.close()
 
 
-class GenotypesPLINK(Genotypes):
+class GenotypesPLINK(GenotypesRefAlt):
     """
     A class for processing genotypes from a PLINK .pgen file
 
     Attributes
     ----------
     data : np.array
-        The genotypes in an n (samples) x p (variants) x 2 (strands) array
+        See documentation for :py:attr:`~.GenotypesRefAlt.data`
     samples : tuple
-        The names of each of the n samples
+        See documentation for :py:attr:`~.GenotypesRefAlt.data`
     variants : np.array
-        Variant-level meta information:
-            1. ID
-            2. CHROM
-            3. POS
-            4. AAF: allele freq of alternate allele (or MAF if to_MAC() is called)
+        See documentation for :py:attr:`~.GenotypesRefAlt.data`
     log: Logger
-        A logging instance for recording debug statements.
+        See documentation for :py:attr:`~.GenotypesRefAlt.data`
+    _prephased: bool
+        See documentation for :py:attr:`~.GenotypesRefAlt.data`
 
     Examples
     --------
-    >>> genotypes = Genotypes.load('tests/data/simple.pgen')
+    >>> genotypes = GenotypesPLINK.load('tests/data/simple.pgen')
     """
 
     def read(

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -142,7 +142,7 @@ class Genotypes(Data):
                     ("aaf", np.float64),
                 ],
             )
-            self.data = np.array(self.data, dtype='u1, u1, ?')
+            self.data = np.array(self.data, dtype=np.uint8)
         else:
             # preallocate arrays! this will save us lots of memory and speed b/c
             # np.append can sometimes make copies
@@ -152,7 +152,7 @@ class Genotypes(Data):
                 ("pos", np.uint),
                 ("aaf", np.float64),
             ])
-            self.data = np.empty((max_variants, len(self.samples), 3), dtype='u1, u1, ?')
+            self.data = np.empty((max_variants, len(self.samples), 3), dtype=np.uint8)
             num_seen = 0
             # save just the variant info we need and discard the rest (to save memory!)
             for variant in vcf(region):
@@ -228,7 +228,7 @@ class Genotypes(Data):
             # 1) presence of REF in strand one
             # 2) presence of REF in strand two
             # 3) whether the genotype is phased
-            data = np.array(variant.genotypes, dtype='u1, u1, ?')
+            data = np.array(variant.genotypes, dtype=np.uint8)
             yield Record(data, samples, variants)
         vcf.close()
 

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -34,6 +34,10 @@ class Genotypes(Data):
     Examples
     --------
     >>> genotypes = Genotypes.load('tests/data/simple.vcf')
+    >>> # directly access the loaded variants, samples, and genotypes (in data)
+    >>> genotypes.variants
+    >>> genotypes.samples
+    >>> genotypes.data
     """
 
     def __init__(self, fname: Path, log: Logger = None):
@@ -43,7 +47,11 @@ class Genotypes(Data):
 
     @classmethod
     def load(
-        cls: Genotypes, fname: Path, region: str = None, samples: list[str] = None
+        cls: Genotypes,
+        fname: Path,
+        region: str = None,
+        samples: list[str] = None,
+        variants: set[str] = None,
     ) -> Genotypes:
         """
         Load genotypes from a VCF file
@@ -58,6 +66,8 @@ class Genotypes(Data):
             See documentation for :py:meth:`~.Genotypes.read`
         samples : list[str], optional
             See documentation for :py:meth:`~.Genotypes.read`
+        variants : set[str], optional
+            See documentation for :py:meth:`~.Genotypes.read`
 
         Returns
         -------
@@ -65,7 +75,7 @@ class Genotypes(Data):
             A Genotypes object with the data loaded into its properties
         """
         genotypes = cls(fname)
-        genotypes.read(region, samples)
+        genotypes.read(region, samples, variants)
         genotypes.check_biallelic()
         genotypes.check_phase()
         # genotypes.to_MAC()

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -444,11 +444,11 @@ class GenotypesPLINK(Genotypes):
         # TODO: figure out how to install this package or just use hail
         from pgenlib import PgenReader
 
-        pgen = PgenReader(bytes(self.fname))
+        pgen = PgenReader(bytes(self.fname, "utf8"))
         sample_ct = pgen.get_raw_sample_ct()
         # the genotypes start out as a simple 2D array with twice the number of samples
         # so each column is a different chromosomal strand
-        self.data = np.empty((variant_ct, sample_ct * 2), dtype="u1, u1")
+        self.data = np.empty((variant_ct, sample_ct * 2), dtype=np.uint32)
         pgen.read_alleles_range(variant_ct_start, variant_ct_end, self.data)
         # extract the genotypes to a np matrix of size n x p x 2
         # the last dimension has two items:

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -72,12 +72,12 @@ class Genotypes(Data):
         return genotypes
 
     def read(
-            self,
-            region: str = None,
-            samples: list[str] = None,
-            variants: set[str] = None,
-            max_variants: int = None
-        ):
+        self,
+        region: str = None,
+        samples: list[str] = None,
+        variants: set[str] = None,
+        max_variants: int = None,
+    ):
         """
         Read genotypes from a VCF into a numpy matrix stored in :py:attr:`~.Genotypes.data`
 
@@ -124,7 +124,9 @@ class Genotypes(Data):
         self.data = []
         if variants:
             max_variants = len(variants)
-        self.log.debug(f"Loading genotypes from {len(self.samples)} samples into memory.")
+        self.log.debug(
+            f"Loading genotypes from {len(self.samples)} samples into memory."
+        )
         # load all info into memory
         # but first, check whether we can preallocate memory instead of making copies
         if max_variants is None:
@@ -136,7 +138,9 @@ class Genotypes(Data):
                 if variants is not None and variant.ID not in variants:
                     continue
                 # save meta information about each variant
-                self.variants.append((variant.ID, variant.CHROM, variant.POS, variant.aaf))
+                self.variants.append(
+                    (variant.ID, variant.CHROM, variant.POS, variant.aaf)
+                )
                 # extract the genotypes to a matrix of size n x p x 3
                 # the last dimension has three items:
                 # 1) presence of REF in strand one
@@ -158,12 +162,15 @@ class Genotypes(Data):
         else:
             # preallocate arrays! this will save us lots of memory and speed b/c
             # np.append can sometimes make copies
-            self.variants = np.empty((max_variants, 4), dtype=[
-                ("id", "U50"),
-                ("chrom", "U10"),
-                ("pos", np.uint),
-                ("aaf", np.float64),
-            ])
+            self.variants = np.empty(
+                (max_variants, 4),
+                dtype=[
+                    ("id", "U50"),
+                    ("chrom", "U10"),
+                    ("pos", np.uint),
+                    ("aaf", np.float64),
+                ],
+            )
             self.data = np.empty((max_variants, len(self.samples), 3), dtype=np.uint8)
             num_seen = 0
             # save just the variant info we need and discard the rest (to save memory!)
@@ -171,7 +178,12 @@ class Genotypes(Data):
                 if variants is not None and variant.ID not in variants:
                     continue
                 # save meta information about each variant
-                self.variants[num_seen] = (variant.ID, variant.CHROM, variant.POS, variant.aaf)
+                self.variants[num_seen] = (
+                    variant.ID,
+                    variant.CHROM,
+                    variant.POS,
+                    variant.aaf,
+                )
                 # extract the genotypes to a matrix of size n x p x 3
                 # the last dimension has three items:
                 # 1) presence of REF in strand one
@@ -379,12 +391,12 @@ class GenotypesPLINK(Genotypes):
     """
 
     def read(
-            self,
-            region: str = None,
-            samples: list[str] = None,
-            variants: set[str] = None,
-            max_variants: int = None
-        ):
+        self,
+        region: str = None,
+        samples: list[str] = None,
+        variants: set[str] = None,
+        max_variants: int = None,
+    ):
         """
         Read genotypes from a VCF into a numpy matrix stored in :py:attr:`~.Genotypes.data`
 
@@ -436,7 +448,7 @@ class GenotypesPLINK(Genotypes):
         sample_ct = pgen.get_raw_sample_ct()
         # the genotypes start out as a simple 2D array with twice the number of samples
         # so each column is a different chromosomal strand
-        self.data = np.empty((variant_ct, sample_ct * 2), dtype='u1, u1')
+        self.data = np.empty((variant_ct, sample_ct * 2), dtype="u1, u1")
         pgen.read_alleles_range(variant_ct_start, variant_ct_end, self.data)
         # extract the genotypes to a np matrix of size n x p x 2
         # the last dimension has two items:

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field, fields
 from typing import Iterator, get_type_hints, Generator
 
 import numpy as np
+import numpy.typing as npt
 from pysam import TabixFile
 
 from .data import Data
@@ -17,6 +18,7 @@ from .genotypes import GenotypesRefAlt
 class Extra:
     """
     An extra field on a line in the .hap file
+
     Attributes
     ----------
     name: str
@@ -330,7 +332,7 @@ class Haplotype:
 
     def transform(
         self, genotypes: GenotypesRefAlt, samples: list[str] = None
-    ) -> npt.NDArray[np.bool_]:
+    ) -> npt.NDArray[bool]:
         """
         Transform a genotypes matrix via the current haplotype
 
@@ -349,7 +351,7 @@ class Haplotype:
 
         Returns
         -------
-        npt.NDArray[np.bool_]
+        npt.NDArray[bool]
             A 2D matrix of shape (num_samples, 2) where each entry in the matrix
             denotes the presence of the haplotype in one chromosome of a sample
         """

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -752,6 +752,7 @@ class Haplotypes(Data):
     def transform(
         self,
         genotypes: GenotypesRefAlt,
+        hap_gts: GenotypesRefAlt,
         samples: list[str] = None,
         low_memory: bool = False,
     ) -> GenotypesRefAlt:
@@ -768,6 +769,9 @@ class Haplotypes(Data):
 
             If the genotypes have not been loaded into the Genotypes object yet, this
             method will call Genotypes.read(), while loading only the needed variants
+        hap_gts: GenotypesRefAlt
+            An empty GenotypesRefAlt object into which the haplotype genotypes should
+            be stored
         samples : list[str], optional
             See documentation for :py:attr:`~.Genotypes.read`
         low_memory : bool, optional
@@ -778,7 +782,6 @@ class Haplotypes(Data):
         GenotypesRefAlt
             A Genotypes object composed of haplotypes instead of regular variants.
         """
-        hap_gts = GenotypesRefAlt(fname=None)
         hap_gts.samples = genotypes.samples
         hap_gts.variants = np.array(
             [(hap.id, hap.chrom, hap.start, 0, "A", "T") for hap in self.data.values()],
@@ -802,4 +805,3 @@ class Haplotypes(Data):
             ),
             axis=1,
         ).astype(np.uint8)
-        return hap_gts

--- a/haptools/haplotype.py
+++ b/haptools/haplotype.py
@@ -45,5 +45,5 @@ class HaptoolsHaplotype(Haplotype):
             the number of columns (second dimension) will have decreased by the number
             of variants in this haplotype.
         """
-        # TODO: implement this
-        pass
+        gens = Genotypes.data
+        records = Genotypes.variants

--- a/haptools/haplotype.py
+++ b/haptools/haplotype.py
@@ -24,26 +24,3 @@ class HaptoolsHaplotype(Haplotype):
             Extra("beta", ".2f", "Effect size in linear model"),
         ),
     )
-
-    def transform(self, genotypes: Genotypes) -> npt.NDArray[np.bool_]:
-        """
-        Transform a genotypes matrix via the current haplotype:
-
-        Each entry in the returned matrix denotes the presence of the current haplotype
-        in each chromosome of each sample in the Genotypes object
-
-        Parameters
-        ----------
-        genotypes : Genotypes
-            The genotypes which to transform using the current haplotype
-
-        Returns
-        -------
-        npt.NDArray[np.bool_]
-            A 3D haplotype matrix similar to the genotype matrix but with haplotypes
-            instead of variants in the columns. It will have the same shape except that
-            the number of columns (second dimension) will have decreased by the number
-            of variants in this haplotype.
-        """
-        gens = Genotypes.data
-        records = Genotypes.variants

--- a/haptools/sim_admixture.py
+++ b/haptools/sim_admixture.py
@@ -4,7 +4,7 @@ import time
 
 import numpy as np
 
-from admix_storage import GeneticMarker, HaplotypeSegment
+from .admix_storage import GeneticMarker, HaplotypeSegment
 
 
 # TODO at a certain point we are going to need to ensure populations in model file are also in invcf files

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -144,7 +144,7 @@ class TestGenotypes:
         gts = Genotypes(DATADIR.joinpath("simple.vcf"))
         for idx, line in enumerate(gts):
             np.testing.assert_allclose(line.data, expected[idx])
-            assert line.samples == samples
+        assert gts.samples == samples
 
     def test_load_genotypes_discard_multiallelic(self):
         expected = self._get_expected_genotypes()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -27,7 +27,6 @@ class TestGenotypes:
         expected[:, :, 2] = 1
         return expected
 
-
     def test_load_genotypes(self, caplog):
         expected = self._get_expected_genotypes()
 
@@ -36,7 +35,6 @@ class TestGenotypes:
         gts.read()
         np.testing.assert_allclose(gts.data, expected)
         assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
-
 
         # try loading the data again - it should warn b/c we've already done it
         caplog.clear()
@@ -65,7 +63,8 @@ class TestGenotypes:
             gts.check_phase()
         assert (
             str(info.value)
-            == "Variant with ID 1:10116:A:G at POS 1:10116 is unphased for sample HG00097"
+            == "Variant with ID 1:10116:A:G at POS 1:10116 is unphased for sample"
+            " HG00097"
         )
         gts.data[1, 1, 2] = 1
 
@@ -91,7 +90,6 @@ class TestGenotypes:
         gts.to_MAC()
         assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
-
     def test_load_genotypes_iterate(self, caplog):
         expected = self._get_expected_genotypes().transpose((1, 0, 2))
         samples = ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
@@ -101,7 +99,6 @@ class TestGenotypes:
         for idx, line in enumerate(gts):
             np.testing.assert_allclose(line.data, expected[idx])
             assert line.samples == samples
-
 
     def test_load_genotypes_discard_multiallelic(self):
         expected = self._get_expected_genotypes()
@@ -122,7 +119,6 @@ class TestGenotypes:
         data_copy_without_biallelic = np.delete(data_copy, [1], axis=1)
         np.testing.assert_equal(gts.data, data_copy_without_biallelic)
         assert gts.variants.shape == tuple(variant_shape)
-
 
     def test_load_genotypes_subset(self):
         expected = self._get_expected_genotypes()
@@ -150,7 +146,7 @@ class TestGenotypes:
 
         gts = Genotypes(DATADIR.joinpath("simple.vcf.gz"))
         samples = ["HG00097", "HG00100"]
-        variants = {'1:10117:C:A'}
+        variants = {"1:10117:C:A"}
         gts.read(region="1:10115-10117", samples=samples, variants=variants)
         np.testing.assert_allclose(gts.data, expected)
         assert gts.samples == tuple(samples)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -477,7 +477,8 @@ class TestHaplotypes:
         gens = TestGenotypes()._get_fake_genotypes_refalt()
         gens.data[[2, 4], 0, 1] = 1
         gens.data[[1, 4], 2, 0] = 1
-        hap_gt = haps.transform(gens)
+        hap_gt = GenotypesRefAlt(fname=None)
+        haps.transform(gens, hap_gt)
         np.testing.assert_allclose(hap_gt.data, expected)
         return hap_gt
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -36,9 +36,11 @@ def test_load_genotypes(caplog):
     np.testing.assert_allclose(gts.data, expected)
     assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
 
+
     # try loading the data again - it should warn b/c we've already done it
+    caplog.clear()
     gts.read()
-    assert len(caplog.records) == 1 and caplog.records[0].levelname == "WARNING"
+    assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
     # force one of the SNPs to have more than one allele and check that we get an error
     gts.data[1, 1, 1] = 2
@@ -72,8 +74,9 @@ def test_load_genotypes(caplog):
     np.testing.assert_allclose(gts.data, expected)
 
     # try to check phase again - it should warn b/c we've already done it before
+    caplog.clear()
     gts.check_phase()
-    assert len(caplog.records) == 2 and caplog.records[1].levelname == "WARNING"
+    assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
     # convert the matrix of alt allele counts to a matrix of minor allele counts
     assert gts.variants["aaf"][1] == 0.6
@@ -83,8 +86,9 @@ def test_load_genotypes(caplog):
     assert gts.variants["maf"][1] == 0.4
 
     # try to do the MAC conversion again - it should warn b/c we've already done it
+    caplog.clear()
     gts.to_MAC()
-    assert len(caplog.records) == 3 and caplog.records[2].levelname == "WARNING"
+    assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
 
 def test_load_genotypes_iterate(caplog):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -87,6 +87,17 @@ class TestGenotypes:
         gts.read()
         assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
+        # force one of the samples to have a missing GT and check that we get an error
+        gts.data[1, 1, 1] = -1
+        with pytest.raises(ValueError) as info:
+            gts.check_missing()
+        assert (
+            str(info.value)
+            == "Genotype with ID 1:10116:A:G at POS 1:10116 is missing for sample"
+            " HG00097"
+        )
+        gts.data[1, 1, 1] = 1
+
         # force one of the SNPs to have more than one allele and check that we get an error
         gts.data[1, 1, 1] = 2
         with pytest.raises(ValueError) as info:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -145,6 +145,16 @@ class TestGenotypes:
         np.testing.assert_allclose(gts.data, expected)
         assert gts.samples == tuple(samples)
 
+        # subset to just one of the variants
+        expected = expected[:, [1]]
+
+        gts = Genotypes(DATADIR.joinpath("simple.vcf.gz"))
+        samples = ["HG00097", "HG00100"]
+        variants = {'1:10117:C:A'}
+        gts.read(region="1:10115-10117", samples=samples, variants=variants)
+        np.testing.assert_allclose(gts.data, expected)
+        assert gts.samples == tuple(samples)
+
 
 def test_load_phenotypes(caplog):
     # create a phenotype vector with shape: num_samples x 1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -32,17 +32,20 @@ class TestGenotypes:
     def _get_fake_genotypes(self):
         gts = Genotypes(fname=None)
         gts.data = self._get_expected_genotypes()
-        gts.variants = np.array([
-            ('1:10114:T:C', '1', 10114, 0),
-            ('1:10116:A:G', '1', 10116, 0.6),
-            ('1:10117:C:A', '1', 10117, 0),
-            ('1:10122:A:G', '1', 10122, 0),
-        ], dtype=[
-            ("id", "U50"),
-            ("chrom", "U10"),
-            ("pos", np.uint32),
-            ("aaf", np.float64),
-        ])
+        gts.variants = np.array(
+            [
+                ("1:10114:T:C", "1", 10114, 0),
+                ("1:10116:A:G", "1", 10116, 0.6),
+                ("1:10117:C:A", "1", 10117, 0),
+                ("1:10122:A:G", "1", 10122, 0),
+            ],
+            dtype=[
+                ("id", "U50"),
+                ("chrom", "U10"),
+                ("pos", np.uint32),
+                ("aaf", np.float64),
+            ],
+        )
         gts.samples = ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
         gts.check_phase()
         return gts
@@ -54,15 +57,18 @@ class TestGenotypes:
         gts.data = base_gts.data
         gts.samples = base_gts.samples
         # add additional ref and alt alleles
-        ref_alt = np.array([
-            ('T', 'C'),
-            ('A', 'G'),
-            ('C', 'A'),
-            ('A', 'G'),
-        ], dtype = [
-            ("ref", "U100"),
-            ("alt", "U100"),
-        ])
+        ref_alt = np.array(
+            [
+                ("T", "C"),
+                ("A", "G"),
+                ("C", "A"),
+                ("A", "G"),
+            ],
+            dtype=[
+                ("ref", "U100"),
+                ("alt", "U100"),
+            ],
+        )
         # see https://stackoverflow.com/a/5356137
         gts.variants = rfn.merge_arrays((base_gts.variants, ref_alt), flatten=True)
         return gts
@@ -428,13 +434,16 @@ class TestHaplotypes:
         os.remove("tests/data/test.hap")
 
     def test_hap_transform(self):
-        expected = np.array([
-            [0, 1],
-            [0, 1],
-            [1, 1],
-            [1, 1],
-            [0, 0],
-        ], dtype=np.uint8)
+        expected = np.array(
+            [
+                [0, 1],
+                [0, 1],
+                [1, 1],
+                [1, 1],
+                [0, 0],
+            ],
+            dtype=np.uint8,
+        )
 
         hap = list(self._get_dummy_haps().data.values())[0]
         gens = TestGenotypes()._get_fake_genotypes_refalt()
@@ -442,13 +451,16 @@ class TestHaplotypes:
         np.testing.assert_allclose(hap_gt, expected)
 
     def test_haps_transform(self):
-        expected = np.array([
-            [[0, 1], [0, 0], [0, 0]],
-            [[0, 1], [0, 0], [1, 0]],
-            [[1, 0], [0, 1], [0, 0]],
-            [[1, 1], [0, 0], [0, 0]],
-            [[0, 0], [0, 1], [1, 0]],
-        ], dtype=np.uint8)
+        expected = np.array(
+            [
+                [[0, 1], [0, 0], [0, 0]],
+                [[0, 1], [0, 0], [1, 0]],
+                [[1, 0], [0, 1], [0, 0]],
+                [[1, 1], [0, 0], [0, 0]],
+                [[0, 0], [0, 1], [1, 0]],
+            ],
+            dtype=np.uint8,
+        )
 
         haps = self._get_dummy_haps()
         gens = TestGenotypes()._get_fake_genotypes_refalt()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,132 +18,132 @@ from haptools.data import (
 DATADIR = Path(__file__).parent.joinpath("data")
 
 
-def get_expected_genotypes():
-    # create a GT matrix with shape: samples x SNPs x (strands+phase)
-    expected = np.zeros(60).reshape((5, 4, 3)).astype(np.uint8)
-    expected[:4, 1, 1] = 1
-    expected[2:4, 1, 0] = 1
-    expected[:, :, 2] = 1
-    return expected
+class TestGenotypes:
+    def _get_expected_genotypes(self):
+        # create a GT matrix with shape: samples x SNPs x (strands+phase)
+        expected = np.zeros(60).reshape((5, 4, 3)).astype(np.uint8)
+        expected[:4, 1, 1] = 1
+        expected[2:4, 1, 0] = 1
+        expected[:, :, 2] = 1
+        return expected
 
 
-def test_load_genotypes(caplog):
-    expected = get_expected_genotypes()
+    def test_load_genotypes(self, caplog):
+        expected = self._get_expected_genotypes()
 
-    # can we load the data from the VCF?
-    gts = Genotypes(DATADIR.joinpath("simple.vcf"))
-    gts.read()
-    np.testing.assert_allclose(gts.data, expected)
-    assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
+        # can we load the data from the VCF?
+        gts = Genotypes(DATADIR.joinpath("simple.vcf"))
+        gts.read()
+        np.testing.assert_allclose(gts.data, expected)
+        assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
 
 
-    # try loading the data again - it should warn b/c we've already done it
-    caplog.clear()
-    gts.read()
-    assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
+        # try loading the data again - it should warn b/c we've already done it
+        caplog.clear()
+        gts.read()
+        assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
-    # force one of the SNPs to have more than one allele and check that we get an error
-    gts.data[1, 1, 1] = 2
-    with pytest.raises(ValueError) as info:
+        # force one of the SNPs to have more than one allele and check that we get an error
+        gts.data[1, 1, 1] = 2
+        with pytest.raises(ValueError) as info:
+            gts.check_biallelic()
+        assert (
+            str(info.value)
+            == "Variant with ID 1:10116:A:G at POS 1:10116 is multiallelic for sample"
+            " HG00097"
+        )
+        gts.data[1, 1, 1] = 1
+
+        # check biallelic-ness and convert to bool_
         gts.check_biallelic()
-    assert (
-        str(info.value)
-        == "Variant with ID 1:10116:A:G at POS 1:10116 is multiallelic for sample"
-        " HG00097"
-    )
-    gts.data[1, 1, 1] = 1
+        expected = expected.astype(np.bool_)
+        np.testing.assert_allclose(gts.data, expected)
 
-    # check biallelic-ness and convert to bool_
-    gts.check_biallelic()
-    expected = expected.astype(np.bool_)
-    np.testing.assert_allclose(gts.data, expected)
+        # force one of the het SNPs to be unphased and check that we get an error message
+        gts.data[1, 1, 2] = 0
+        with pytest.raises(ValueError) as info:
+            gts.check_phase()
+        assert (
+            str(info.value)
+            == "Variant with ID 1:10116:A:G at POS 1:10116 is unphased for sample HG00097"
+        )
+        gts.data[1, 1, 2] = 1
 
-    # force one of the het SNPs to be unphased and check that we get an error message
-    gts.data[1, 1, 2] = 0
-    with pytest.raises(ValueError) as info:
+        # check phase and remove the phase axis
         gts.check_phase()
-    assert (
-        str(info.value)
-        == "Variant with ID 1:10116:A:G at POS 1:10116 is unphased for sample HG00097"
-    )
-    gts.data[1, 1, 2] = 1
+        expected = expected[:, :, :2]
+        np.testing.assert_allclose(gts.data, expected)
 
-    # check phase and remove the phase axis
-    gts.check_phase()
-    expected = expected[:, :, :2]
-    np.testing.assert_allclose(gts.data, expected)
+        # try to check phase again - it should warn b/c we've already done it before
+        caplog.clear()
+        gts.check_phase()
+        assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
-    # try to check phase again - it should warn b/c we've already done it before
-    caplog.clear()
-    gts.check_phase()
-    assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
+        # convert the matrix of alt allele counts to a matrix of minor allele counts
+        assert gts.variants["aaf"][1] == 0.6
+        gts.to_MAC()
+        expected[:, 1, :] = ~expected[:, 1, :]
+        np.testing.assert_allclose(gts.data, expected)
+        assert gts.variants["maf"][1] == 0.4
 
-    # convert the matrix of alt allele counts to a matrix of minor allele counts
-    assert gts.variants["aaf"][1] == 0.6
-    gts.to_MAC()
-    expected[:, 1, :] = ~expected[:, 1, :]
-    np.testing.assert_allclose(gts.data, expected)
-    assert gts.variants["maf"][1] == 0.4
-
-    # try to do the MAC conversion again - it should warn b/c we've already done it
-    caplog.clear()
-    gts.to_MAC()
-    assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
+        # try to do the MAC conversion again - it should warn b/c we've already done it
+        caplog.clear()
+        gts.to_MAC()
+        assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
 
-def test_load_genotypes_iterate(caplog):
-    expected = get_expected_genotypes().transpose((1, 0, 2))
-    samples = ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
+    def test_load_genotypes_iterate(self, caplog):
+        expected = self._get_expected_genotypes().transpose((1, 0, 2))
+        samples = ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
 
-    # can we load the data from the VCF?
-    gts = Genotypes(DATADIR.joinpath("simple.vcf"))
-    for idx, line in enumerate(gts):
-        np.testing.assert_allclose(line.data, expected[idx])
-        assert line.samples == samples
-
-
-def test_load_genotypes_discard_multiallelic():
-    expected = get_expected_genotypes()
-
-    # can we load the data from the VCF?
-    gts = Genotypes(DATADIR.joinpath("simple.vcf"))
-    gts.read()
-
-    # make a copy for later
-    data_copy = gts.data.copy().astype(np.bool_)
-    variant_shape = list(gts.variants.shape)
-    variant_shape[0] -= 1
-
-    # force one of the SNPs to have more than one allele and check that it gets dicarded
-    gts.data[1, 1, 1] = 2
-    gts.check_biallelic(discard_also=True)
-
-    data_copy_without_biallelic = np.delete(data_copy, [1], axis=1)
-    np.testing.assert_equal(gts.data, data_copy_without_biallelic)
-    assert gts.variants.shape == tuple(variant_shape)
+        # can we load the data from the VCF?
+        gts = Genotypes(DATADIR.joinpath("simple.vcf"))
+        for idx, line in enumerate(gts):
+            np.testing.assert_allclose(line.data, expected[idx])
+            assert line.samples == samples
 
 
-def test_load_genotypes_subset():
-    expected = get_expected_genotypes()
+    def test_load_genotypes_discard_multiallelic(self):
+        expected = self._get_expected_genotypes()
 
-    # subset for the region we want
-    expected = expected[:, 1:3]
+        # can we load the data from the VCF?
+        gts = Genotypes(DATADIR.joinpath("simple.vcf"))
+        gts.read()
 
-    # can we load the data from the VCF?
-    gts = Genotypes(DATADIR.joinpath("simple.vcf.gz"))
-    gts.read(region="1:10115-10117")
-    np.testing.assert_allclose(gts.data, expected)
-    assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
+        # make a copy for later
+        data_copy = gts.data.copy().astype(np.bool_)
+        variant_shape = list(gts.variants.shape)
+        variant_shape[0] -= 1
 
-    # subset for just the samples we want
-    expected = expected[[1, 3]]
+        # force one of the SNPs to have more than one allele and check that it gets dicarded
+        gts.data[1, 1, 1] = 2
+        gts.check_biallelic(discard_also=True)
 
-    # can we load the data from the VCF?
-    gts = Genotypes(DATADIR.joinpath("simple.vcf.gz"))
-    samples = ["HG00097", "HG00100"]
-    gts.read(region="1:10115-10117", samples=samples)
-    np.testing.assert_allclose(gts.data, expected)
-    assert gts.samples == tuple(samples)
+        data_copy_without_biallelic = np.delete(data_copy, [1], axis=1)
+        np.testing.assert_equal(gts.data, data_copy_without_biallelic)
+        assert gts.variants.shape == tuple(variant_shape)
+
+
+    def test_load_genotypes_subset(self):
+        expected = self._get_expected_genotypes()
+
+        # subset for the region we want
+        expected = expected[:, 1:3]
+
+        # can we load the data from the VCF?
+        gts = Genotypes(DATADIR.joinpath("simple.vcf.gz"))
+        gts.read(region="1:10115-10117")
+        np.testing.assert_allclose(gts.data, expected)
+        assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
+
+        # subset for just the samples we want
+        expected = expected[[1, 3]]
+
+        gts = Genotypes(DATADIR.joinpath("simple.vcf.gz"))
+        samples = ["HG00097", "HG00100"]
+        gts.read(region="1:10115-10117", samples=samples)
+        np.testing.assert_allclose(gts.data, expected)
+        assert gts.samples == tuple(samples)
 
 
 def test_load_phenotypes(caplog):


### PR DESCRIPTION
resolves #33 
**note**: please merge this before #43 !

## Overview
This PR adds a subcommand to output haplotypes in VCF format, so that we can obtain counts of each haplotype in each chromosome of each sample. This functionality is primarily handled by a new `Haplotype.transform()` method.
There is also a `Haplotypes.transform()` method to transform multiple haplotypes at once. At the moment, `Haplotypes.transform()` just calls `Haplotype.transform()` repeatedly, but I think there might be ways to make this faster.

There are also new methods to write the haplotypes to a VCF and some small improvements to make reading from VCFs less memory-intensive.

## Usage and docs
I've documented the `transform` subcommand [here](https://haptools--45.org.readthedocs.build/en/45/commands/transform.html) in the _commands_ section.

Usage of the `transform()` methods for the `Haplotype` and `Haplotypes` classes are documented in the API docs [here](https://haptools--45.org.readthedocs.build/en/45/api/haptools.html#haptools.data.haplotypes.Haplotype.transform) and [here](https://haptools--45.org.readthedocs.build/en/45/api/haptools.html#haptools.data.haplotypes.Haplotypes.transform), respectively.

## Testing
I added the following tests to the `TestHaplotypes` class in `tests/test_data.py`:

1. `test_hap_transform()`
    Try the `Haplotype.transform()` method on a basic haplotype and its genotypes.
2. `test_haps_transform()`
    Try the `Haplotypes.transform()` method on a set of basic haplotypes and genotypes.
3. `test_hap_gt_write()`
    Try to write haplotypes to a VCF. Read the VCF back and check that it looks like what we would expect.