### PR TITLE
fix: conflicting short params in simphenotype

### DIFF
--- a/docs/commands/simphenotype.rst
+++ b/docs/commands/simphenotype.rst
@@ -20,9 +20,9 @@ Usage
    --heritability FLOAT \
    --prevalence FLOAT \
    --region TEXT \
-   --sample SAMPLE \
+   --sample SAMPLE --sample SAMPLE \
    --samples-file FILENAME \
-   --hap-id ID \
+   --id ID --id ID \
    --chunk-size INT \
    --output PATH \
    --verbosity [CRITICAL|ERROR|WARNING|INFO|DEBUG|NOTSET] \

--- a/docs/commands/transform.rst
+++ b/docs/commands/transform.rst
@@ -16,9 +16,10 @@ Usage
 
 	haptools transform \
 	--region TEXT \
-	--sample SAMPLE \
+	--sample SAMPLE --sample SAMPLE \
 	--samples-file FILENAME \
-	--hap-id ID \
+	--id ID --id ID \
+	--ids-file FILENAME \
 	--chunk-size INT \
 	--discard-missing \
 	--output PATH \

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -167,15 +167,14 @@ def simgenotype(invcf, sample_info, model, mapdir, out, popsize, seed, chroms, o
     ),
 )
 @click.option(
-    "-h",
-    "--hap-id",
-    "haplotype_ids",
+    "-i",
+    "--id",
+    "ids",
     type=str,
     multiple=True,
     show_default="all haplotypes",
     help=(
-        "A list of the haplotype IDs to use from the .hap file (ex: '-h H1 -h H2')."
-        "\nFor this to work, the .hap file must be indexed"
+        "A list of the haplotype IDs to use from the .hap file (ex: '-i H1 -i H2')."
     ),
 )
 @click.option(
@@ -211,7 +210,7 @@ def simphenotype(
     region: str = None,
     samples: tuple[str] = tuple(),
     samples_file: Path = None,
-    haplotype_ids: tuple[str] = tuple(),
+    ids: tuple[str] = tuple(),
     chunk_size: int = None,
     output: Path = Path("-"),
     verbosity: str = 'ERROR',
@@ -297,10 +296,15 @@ def simphenotype(
     else:
         samples = None
 
+    if ids:
+        ids = set(ids)
+    else:
+        ids = None
+
     # Run simulation
     simulate_pt(
         genotypes, haplotypes, replications, heritability, prevalence, region, samples,
-        haplotype_ids, chunk_size, output, log
+        ids, chunk_size, output, log
     )
 
 @main.command(short_help="Transform a genotypes matrix via a set of haplotypes")
@@ -340,15 +344,25 @@ def simphenotype(
     ),
 )
 @click.option(
-    "-h",
-    "--hap-id",
-    "haplotype_ids",
+    "-i",
+    "--id",
+    "ids",
     type=str,
     multiple=True,
     show_default="all haplotypes",
     help=(
-        "A list of the haplotype IDs to use from the .hap file (ex: '-h H1 -h H2')."
-        "\nFor this to work, the .hap file must be indexed"
+        "A list of the haplotype IDs to use from the .hap file (ex: '-i H1 -i H2')."
+    ),
+)
+@click.option(
+    "-I",
+    "--ids-file",
+    type=str,
+    multiple=True,
+    show_default="all haplotypes",
+    help=(
+        "A single column txt file containing a list of the haplotype IDs "
+        "(one per line) to subset from the .hap file"
     ),
 )
 @click.option(
@@ -425,7 +439,7 @@ def transform(
     samples_file : Path, optional
         A single column txt file containing a list of the samples (one per line) to
         subset from the genotypes file
-    haplotype_ids: tuple[str], optional
+    ids: tuple[str], optional
         A list of haplotype IDs to obtain from the .hap file. All others are ignored.
 
         If not provided, all haplotypes will be used.
@@ -467,13 +481,16 @@ def transform(
     else:
         samples = None
 
-    if haplotype_ids:
-        haplotype_ids = set(haplotype_ids)
+    if ids_file:
+        with ids_file as id_file:
+            ids = set(id_file.read().splitlines())
+    elif ids:
+        ids = set(ids)
     else:
-        haplotype_ids = None
+        ids = None
 
     transform_haps(
-        genotypes, haplotypes, region, samples, haplotype_ids, chunk_size,
+        genotypes, haplotypes, region, samples, ids, chunk_size,
         discard_missing, output, log
     )
 

--- a/haptools/sim_phenotype.py
+++ b/haptools/sim_phenotype.py
@@ -194,7 +194,7 @@ def simulate_pt(
     prevalence: float = None,
     region: str = None,
     samples: list[str] = None,
-    haplotype_ids: tuple[str] = tuple(),
+    haplotype_ids: set[str] = None,
     chunk_size: int = None,
     output: Path = Path("-"),
     log: Logger = None,
@@ -242,7 +242,7 @@ def simulate_pt(
     samples_file : Path, optional
         A single column txt file containing a list of the samples (one per line) to
         subset from the genotypes file
-    haplotype_ids: tuple[str], optional
+    haplotype_ids: set[str], optional
         A list of haplotype IDs to obtain from the .hap file. All others are ignored.
 
         If not provided, all haplotypes will be used.


### PR DESCRIPTION
This fixes an issue in `simphenotype` where the `-h` parameter meant two different things.